### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,9 +7,9 @@
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "parallel": 1,
-        "accessToken": "ODhhNzU1NzgtY2FlMS00NDA2LTlhZWItYzcxNDJiZDllYjAyfHJlYWQtd3JpdGU=",
+        "accessToken": "ZWY1NzYzZDEtNWNhNS00NWRiLTljNmQtOGI3NzRlZGU3MzdhfHJlYWQtd3JpdGU=",
         "url": "https://staging.nx.app",
-        "nxCloudUrl": "https://staging.nx.app"
+        "nxCloudUrl": "https://crezco.gc.ent.nx.app"
       }
     }
   },


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://crezco.gc.ent.nx.app/orgs/683983350b3b39bff21504bf/workspaces/6839833e0b3b39bff21504c1

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.